### PR TITLE
Fix wrong redirect to the web wallet in case of not logged in user that are trying to sign a message

### DIFF
--- a/src/pages/SignMessage/SignMessage.tsx
+++ b/src/pages/SignMessage/SignMessage.tsx
@@ -45,6 +45,7 @@ export const SignMessage = () => {
       const isWallet = loginMethod === 'wallet';
 
       navigate(isWallet ? encodeURIComponent(route) : route);
+      return;
     }
 
     const signableMessage = await signMessage({


### PR DESCRIPTION
How to reproduce?

1. Ensure you are not logged in.
2. Go to /sign-message route
3. Insert a test in the first input and press "Sign"
4. You will be redirected to the /unlock page, but at the same time, some code is executed and forces a redirect to the web wallet.