### PR TITLE
Fix wrong redirect to the web wallet in case of not logged in user that are trying to sign a message (#43)

### DIFF
--- a/src/pages/SignMessage/SignMessage.tsx
+++ b/src/pages/SignMessage/SignMessage.tsx
@@ -45,6 +45,7 @@ export const SignMessage = () => {
       const isWallet = loginMethod === 'wallet';
 
       navigate(isWallet ? encodeURIComponent(route) : route);
+      return;
     }
 
     const signableMessage = await signMessage({

--- a/src/pages/SignMessage/components/VerifySignatureFormFields.tsx
+++ b/src/pages/SignMessage/components/VerifySignatureFormFields.tsx
@@ -109,6 +109,7 @@ export const VerifySignatureFormFields = ({
                 className={styles.field}
                 key={initialVerifyFormValues.toString()}
                 autoComplete='off'
+                placeholder='Insert or paste the message that was signed.'
                 onChange={handleChange}
               />
 
@@ -128,6 +129,7 @@ export const VerifySignatureFormFields = ({
                 className={styles.field}
                 key={initialVerifyFormValues.toString()}
                 autoComplete='off'
+                placeholder="Insert or paste the signature. You don't have to add '0x' prefix."
                 onChange={handleChange}
               />
 


### PR DESCRIPTION
* fix wrong redirect to the web wallet in case of not logged in user that are trying to sign a message

* add placeholders that explain better what should be placed in the verify signature fields section